### PR TITLE
fixes for huffman

### DIFF
--- a/src/main/scala/huffman/compressor/compressorOutput.scala
+++ b/src/main/scala/huffman/compressor/compressorOutput.scala
@@ -14,10 +14,6 @@ import huffmanParameters._
   * value in register x is then the compressorOutput
   */
 class compressorOutput(params: huffmanParameters) extends Module {
-  // This checks if a thread should be done accepting data when variable compression is enabled.
-  def checkIfThreadFinished(iterations: UInt, index: Int, compressionLimit: UInt): Bool = {
-    iterations * params.compressionParallelism.U + index.U >= compressionLimit
-  }
   val io = IO(new Bundle {
     val start = Input(Bool())
     //  data in
@@ -44,10 +40,6 @@ class compressorOutput(params: huffmanParameters) extends Module {
     Enum(numberOfStates)
   val state = RegInit(UInt(log2Ceil(numberOfStates + 1).W), waiting)
 
-  val iterations = Reg(
-    Vec(params.compressionParallelism, UInt(params.inputCharacterBits.W))
-  )
-
   // This is needed in case the state is not one of the defined states. Sadly, Chisel does not yet
   // support a "default" for switch statements, so  this needs to be used to be sure that the outputs
   // are defined for all scenarios.
@@ -63,32 +55,8 @@ class compressorOutput(params: huffmanParameters) extends Module {
 
   switch(state) {
     is(waiting) {
-      for (index <- 0 until params.compressionParallelism) {
-        iterations(index) := 0.U
-      }
       when(io.start) {
-        if (params.variableCompression) {
-          state := writingCompressionLimit
-        } else {
-          state := writingTree
-        }
-      }
-    }
-
-    is(writingCompressionLimit) {
-      if (params.variableCompression) {
-        for (index <- 0 until params.compressionParallelism) {
-          iterations(index) := 0.U
-        }
-        io.outputs(0).valid := true.B
-        io.outputs(0).dataLength := params.inputCharacterBits.U
-        io.outputs(0).dataOut := io
-          .dataIn(0)
-          .compressionLimit
-          .get << (params.dictionaryEntryMaxBits.U - io.outputs(0).dataLength)
-        when(io.outputs(0).ready) {
-          state := writingTree
-        }
+        state := writingTree
       }
     }
 
@@ -97,7 +65,6 @@ class compressorOutput(params: huffmanParameters) extends Module {
       // Because it isn't encoding yet, none of the inputs need to be read from.
       for (index <- 0 until params.compressionParallelism) {
         input(index).io.dataOut.ready := false.B
-        input(index).io.currentByte := 0.U
       }
 
       // This sets empty values for all of the outputs that aren't working during this state.
@@ -106,6 +73,8 @@ class compressorOutput(params: huffmanParameters) extends Module {
         io.outputs(index).valid := false.B
         io.outputs(index).dataLength := 0.U
       }
+      val iterations =
+        Seq(RegInit(UInt(log2Ceil(params.huffmanTreeCharacters).W), 0.U))
       // Sets some of the outputs of the primary serial tree output. Dictionary entry length is always the same between
       // different entries.
       io.outputs(0).valid := true.B
@@ -145,75 +114,23 @@ class compressorOutput(params: huffmanParameters) extends Module {
       }
 
       when(io.outputs(0).ready) {
-        iterations(0) := iterations(0) + 1.U
-        when(iterations(0) + 1.U >= params.huffmanTreeCharacters.U) {
+        when(when.cond){iterations(0) := iterations(0) + 1.U}
+        when(iterations(0) === (params.huffmanTreeCharacters - 1).U) {
           state := writingData
-          for (index <- 0 until params.compressionParallelism) {
-            iterations(index) := 0.U
-          }
         }
       }
     }
 
     is(writingData) {
-      // This generates the hardware once for each of the parallel compressors. If all their data is
-      // valid, they output the necessary data and go to the next iteration.
       for (index <- 0 until params.compressionParallelism) {
-        // Setting the default values
-        io.outputs(index).valid := false.B
-        io.outputs(index).dataLength := 0.U
-        io.outputs(index).dataOut := 0.U
-        input(index).io.currentByte := DontCare
-        input(index).io.dataOut.ready := false.B
-
-        val continueIterating = Wire(Bool())
-        if (params.variableCompression) {
-          continueIterating := !checkIfThreadFinished(iterations(index), index, io.dataIn(index).compressionLimit.get)
-        } else {
-          continueIterating := iterations(index) < params.parallelCharacters.U
-        }
-        // This performs the parallel compression for threads that still aren't finished
-        when(continueIterating) {
-          // This calculates which byte is being requested.
-          input(index).io.currentByte := iterations(index) * params.compressionParallelism.U + index.U
-          // THe input is only ready for data if the output is ready to receive data.
-          input(index).io.dataOut.ready := io.outputs(index).ready
-          when(input(index).io.dataOut.valid) {
-            io.outputs(index).valid := true.B
-            when(io.inputs.escapeCharacters(input(index).io.dataOut.bits(0))) {
-              // The character is an escape character, so calculate its length.
-              io.outputs(index).dataLength := io.inputs.lengths(input(index).io.dataOut.bits(0))
-            }.otherwise {
-              // The character is not an escape character, so use its defined length.
-              io.outputs(index).dataLength := io.inputs.lengths(input(index).io.dataOut.bits(0))
-            }
-            io.outputs(index).dataOut := io.inputs
-              .codewords(input(index).io.dataOut.bits(0)) << (params.dictionaryEntryMaxBits.U - io.outputs(index).dataLength)
-            when(io.outputs(index).ready) {
-              iterations(index) := iterations(index) + 1.U
-            }
-          }
-        }
+        input(index).io.dataOut.ready := io.outputs(index).ready
+        io.outputs(index).valid := input(index).io.dataOut.valid
+        io.outputs(index).dataLength :=
+          io.inputs.lengths(input(index).io.dataOut.bits(0))
+        io.outputs(index).dataOut :=
+          io.inputs.codewords(input(index).io.dataOut.bits(0))
+          .<<(params.dictionaryEntryMaxBits.U - io.outputs(index).dataLength)
       }
-
-      if (params.variableCompression) {
-        // Once all the threads of compression have completed all the valid characters, transition into the waiting state.
-        when(
-          iterations.zipWithIndex.map({ case (value, index) => checkIfThreadFinished(value, index, io.dataIn(index).compressionLimit.get) }).reduce(_ && _)
-        ) {
-          state := waiting
-        }
-      } else {
-        // Once all the threads of compression are completed, transition to the waiting state.
-        // Map performs the anonymous function on each element of iterations (each iteration of
-        // the function, the element of the iterations vector replaces the "_" in the input to map),
-        // and reduce does an AND reduce on the output Bools from the map function, with each run of
-        // the reduction replacing the two "_"s with the corresponding two inputs.
-        when(iterations.map(_ >= params.parallelCharacters.U).reduce(_ && _)) {
-          state := waiting
-        }
-      }
-
     }
   }
 


### PR DESCRIPTION
some things this fixes:
 - disabled compression limit (frequency counting still has a limit)
 - decompressor reports ready count instead of currentBit
 - currentBit removed from compressor (ready/valid is sufficient)
 - decompressor reports correct number of bits consumed for escape codes
 - needless logic dependencies eliminated

still some lose ends:
 - does not remove compressor currentBit output in order to avoid some compilation errors for other classes
 - may break other classes that make use of huffman
 - does not address all known issues